### PR TITLE
Automate the creation of datapack zips upon tag creation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,53 @@
+name: Create draft release with zipped datapacks
+# Trigger on new tag
+on:
+  push:
+    tags:
+      - "v*.*.*"
+
+env:
+  # Name of the archive .zip and .tar.gz archives without extension. Tag will be appended to this.
+  ARCHIVE_PREFIX: ${{ github.event.repository.name }}
+  ARCHIVE_DIR: datapack
+
+jobs:
+  build-and-draft-release:
+    runs-on: ubuntu-latest
+    strategy:
+      max-parallel: 1
+      matrix:
+        include:
+          - minecraft_version: 1.17.1
+            pack_format: 7
+          - minecraft_version: 1.18.2
+            pack_format: 9
+          - minecraft_version: 1.19
+            pack_format: 10
+
+    steps:
+      # Checkout repository.
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      # Set the pack_format that matches the minecraft_version
+      - name: Set pack_format
+        run: |
+          sed -i 's/\"pack_format\":\ [0-9]\+,/\"pack_format\":\ ${{ matrix.pack_format }},/' datapack/pack.mcmeta
+      
+      # Set ARCHIVE_NAME variable from ARCHIVE_PREFIX and tag name.
+      - name: Set ARCHIVE_NAME
+        run: echo "ARCHIVE_NAME=${ARCHIVE_PREFIX}_${GITHUB_REF/refs\/tags\//}_mc${{ matrix.minecraft_version }}" >> $GITHUB_ENV
+      
+      # Archive binary files.
+      - name: Archive binary files
+        run: |
+          cd $ARCHIVE_DIR
+          zip -r $ARCHIVE_NAME.zip *
+      
+      # Create a release draft
+      - name: Create draft release
+        uses: softprops/action-gh-release@v1
+        with:
+          draft: true
+          files: |
+            ${{ env.ARCHIVE_DIR }}/${{ env.ARCHIVE_NAME }}.zip


### PR DESCRIPTION
## What this does
I created an action that runs whenever you create a new tag. The action automatically sets the correct `pack_format` corresponding to the Minecraft version and creates a zip file. It does this for version `1.17.1`, `1.18.2` and `1.19`. When it is finished, it creates a new draft release and adds the zip files to it.

## How to use it
- Every time you want to release a new version, just create a new tag. The workflow will do the rest.
- When the workflow is finished, it will have created a draft release. Check if it correct and optionally add a description. You can then save it (not as a draft) to make the release public.

## Other suggestions
I suggest that you just link to the releases page with some info on which file to download and remove the individual links in your README. No more manual work![^1].

## Tests
These are links to the final test results.
Workflow run: https://github.com/n-vr/Vegan-Minecraft/actions/runs/2514959287
Release: https://github.com/n-vr/Vegan-Minecraft/releases/tag/v1.1.1-test

[^1]: Almost... :smile: 